### PR TITLE
ace 行号栏 z-index 过高 #358

### DIFF
--- a/dubbo-admin-ui/src/components/public/JsonEditor.vue
+++ b/dubbo-admin-ui/src/components/public/JsonEditor.vue
@@ -90,4 +90,7 @@
     width: 100%;
     height: 100%;
   }
+  >>> .ace_gutter {
+    z-index: auto;
+  }
 </style>


### PR DESCRIPTION
方法测试页面编辑器模式选择 “code” 时，编辑器样式错位 https://github.com/apache/dubbo-admin/issues/358