### PR TITLE
fix dubbo-admin-server starting RuntimeException

### DIFF
--- a/dubbo-admin-ui/src/components/metrics/ServiceRelation.vue
+++ b/dubbo-admin-ui/src/components/metrics/ServiceRelation.vue
@@ -34,14 +34,11 @@
 </template>
 <script>
   import Breadcrumb from '@/components/public/Breadcrumb'
-  import axios from 'axios'
   export default {
     components: {
-      Breadcrumb,
-      axios
+      Breadcrumb
     },
     data: () => ({
-      baseURL: '/api/dev',
       success: null,
       breads: [
         {
@@ -60,7 +57,7 @@
         // eslint-disable-next-line no-undef
         this.chartContent = echarts.init(document.getElementById('chartContent'))
         this.chartContent.showLoading()
-        axios.get(this.baseURL + '/metrics/relation')
+        this.$axios.get('/metrics/relation')
           .then(response => {
             if (response && response.status === 200) {
               this.success = true


### PR DESCRIPTION
## What is the purpose of the change
Escape one  RuntimeException when the dubbo-admin-server starting!

## Brief changelog
If we use dubbo-admin to manage dubbo-2.7+ apps, we just only config _admin.config-center_ property is ok. But now there is one RuntimeException when the dubbo-admin-server starting if we not config 
 _admin.registry.address_ property!

## Verifying this change

dubbo-admin-server: application.properties
```
#admin.registry.address=nacos://127.0.0.1:2181
admin.config-center=nacos://127.0.0.1:2181
admin.metadata-report.address=nacos://127.0.0.1:2181
```
#### Change before
<img width="1376" alt="1" src="https://user-images.githubusercontent.com/5526657/69861314-194b8300-12d3-11ea-88cd-9f20a884477d.png">

#### Change after
<img width="1375" alt="2" src="https://user-images.githubusercontent.com/5526657/69861326-21a3be00-12d3-11ea-8955-e0ffebad6a5a.png">
