### PR TITLE
修复metrics搜索白屏的BUG

### DIFF
--- a/dubbo-admin-ui/src/components/metrics/ServiceMetrics.vue
+++ b/dubbo-admin-ui/src/components/metrics/ServiceMetrics.vue
@@ -338,7 +338,7 @@
         }
 
         if (rewrite) {
-          this.$router.push({path: '/metrics', query: {ip: this.filter}})
+          this.$router.push({path: '/metrics/index', query: {ip: this.filter}})
         }
         let url = '/metrics/ipAddr/?ip=' + filter + '&group=dubbo'
         this.$axios.get(url)


### PR DESCRIPTION
路由跳转错误，正确的应该是/metrics/index