### PR TITLE
修复同一台机器多个Dubbo服务只能监控其中一个的问题

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/controller/MetricsCollectController.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/controller/MetricsCollectController.java
@@ -101,24 +101,30 @@ public class MetricsCollectController {
     protected void addMetricsConfigToMap(Map<String, String> configMap, String ip) {
         List<Provider> providers = providerService.findByAddress(ip);
         if (providers.size() > 0) {
-            Provider provider = providers.get(0);
-            String service = provider.getService();
-            MetadataIdentifier providerIdentifier = new MetadataIdentifier(Tool.getInterface(service), Tool.getVersion(service), Tool.getGroup(service),
-                    Constants.PROVIDER_SIDE, provider.getApplication());
-            String metaData = providerService.getProviderMetaData(providerIdentifier);
-            FullServiceDefinition providerServiceDefinition = new Gson().fromJson(metaData, FullServiceDefinition.class);
-            Map<String, String> parameters = providerServiceDefinition.getParameters();
-            configMap.put(parameters.get(Constants.METRICS_PORT), parameters.get(Constants.METRICS_PROTOCOL));
+            for(Provider provider : providers) {
+                String service = provider.getService();
+                MetadataIdentifier providerIdentifier = new MetadataIdentifier(Tool.getInterface(service), Tool.getVersion(service), Tool.getGroup(service),
+                        Constants.PROVIDER_SIDE, provider.getApplication());
+                String metaData = providerService.getProviderMetaData(providerIdentifier);
+                FullServiceDefinition providerServiceDefinition = new Gson().fromJson(metaData, FullServiceDefinition.class);
+                Map<String, String> parameters = providerServiceDefinition.getParameters();
+                if(parameters.containsKey(Constants.METRICS_PORT)) {
+                    configMap.put(parameters.get(Constants.METRICS_PORT), parameters.get(Constants.METRICS_PROTOCOL));
+                }
+            }
         } else {
             List<Consumer> consumers = consumerService.findByAddress(ip);
             if (consumers.size() > 0) {
-                Consumer consumer = consumers.get(0);
-                String service = consumer.getService();
-                MetadataIdentifier consumerIdentifier = new MetadataIdentifier(Tool.getInterface(service), Tool.getVersion(service), Tool.getGroup(service),
-                        Constants.CONSUMER_SIDE, consumer.getApplication());
-                String metaData = consumerService.getConsumerMetadata(consumerIdentifier);
-                Map<String, String> consumerParameters = new Gson().fromJson(metaData, Map.class);
-                configMap.put(consumerParameters.get(Constants.METRICS_PORT), consumerParameters.get(Constants.METRICS_PROTOCOL));
+                for(Consumer consumer : consumers) {
+                    String service = consumer.getService();
+                    MetadataIdentifier consumerIdentifier = new MetadataIdentifier(Tool.getInterface(service), Tool.getVersion(service), Tool.getGroup(service),
+                            Constants.CONSUMER_SIDE, consumer.getApplication());
+                    String metaData = consumerService.getConsumerMetadata(consumerIdentifier);
+                    Map<String, String> consumerParameters = new Gson().fromJson(metaData, Map.class);
+                    if(consumerParameters.containsKey(Constants.METRICS_PORT)) {
+                        configMap.put(consumerParameters.get(Constants.METRICS_PORT), consumerParameters.get(Constants.METRICS_PROTOCOL));
+                    }
+                }
             }
         }
     }

--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/controller/MetricsCollectController.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/controller/MetricsCollectController.java
@@ -73,7 +73,7 @@ public class MetricsCollectController {
 
     private String getOnePortMessage(String group, String ip, String port, String protocol) {
         MetrcisCollectServiceImpl metrcisCollectService = new MetrcisCollectServiceImpl();
-        metrcisCollectService.setUrl(protocol + "://" + ip + ":" + port +"?scope=remote&cache=true");
+        metrcisCollectService.setUrl(protocol + "://" + ip + ":" + port +"?scope=remote");
         String res = metrcisCollectService.invoke(group).toString();
         return res;
     }

--- a/dubbo-admin-ui/src/components/metrics/ServiceMetrics.vue
+++ b/dubbo-admin-ui/src/components/metrics/ServiceMetrics.vue
@@ -330,7 +330,7 @@
     * */
     methods: {
       submit: function () {
-        this.searchByIp(this.filter, true)
+        this.searchByIp(this.filter, false)
       },
       searchByIp: function (filter, rewrite) {
         if (this.filter === '') {


### PR DESCRIPTION
1、修复同一台机器多个Dubbo服务只能监控其中一个的问题
2、修复configMap存入{null:null}导致没配置端口时不应用默认端口，报null错误的问题