### PR TITLE
修复应用级别配置创建后不生效的问题

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/common/util/Constants.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/common/util/Constants.java
@@ -28,7 +28,7 @@ public class Constants {
     public static final String DEFAULT_ROOT = "dubbo";
     public static final String PATH_SEPARATOR = "/";
     public static final String GROUP_KEY = "group";
-    public static final String CONFIG_KEY = "config" + PATH_SEPARATOR + "dubbo";
+    public static final String CONFIG_KEY = "config";
     public static final String DUBBO_PROPERTY = "dubbo.properties";
     public static final String PROVIDER_SIDE = "provider";
     public static final String CONSUMER_SIDE = "consumer";


### PR DESCRIPTION
此处会导致bug【配置管理只能创建global级别的配置，不能创建应用级别】
按照Dubbo源码的定义，配置都应该在都在config下面，应用级配置的路径应该跟config/dubbo同级。
根据ManagementServiceImpl.getPath这个方法内的逻辑，此处应为“config”。
从代码来看，这么修改也符合这个常量类的定义。【估计是改其他BUG的时候引出来的新问题】