### PR TITLE
修复nacos作为注册中心时无法正确读取元数据的问题

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/config/ConfigCenter.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/config/ConfigCenter.java
@@ -96,9 +96,9 @@ public class ConfigCenter {
                 Arrays.stream(config.split("\n")).forEach( s -> {
                     if(s.startsWith(Constants.REGISTRY_ADDRESS)) {
                         String registryAddress = s.split("=")[1].trim();
-                        registryUrl = formUrl(registryAddress, configCenterGroup, username, password);
+                        registryUrl = formUrl(registryAddress, registryGroup, username, password);
                     } else if (s.startsWith(Constants.METADATA_ADDRESS)) {
-                        metadataUrl = formUrl(s.split("=")[1].trim(), configCenterGroup, username, password);
+                        metadataUrl = formUrl(s.split("=")[1].trim(), metadataGroup, username, password);
                     }
                 });
             }


### PR DESCRIPTION
nacos作为注册中心时，dubbo-admin 未正确使用配置分组导致无法正确展示元数据的问题