### PR TITLE
fix problem in README.md and README_ZH.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ service governance follows the version of Dubbo 2.7, and compatible for Dubbo 2.
 2. Specify registry address in `dubbo-admin-server/src/main/resources/application.properties`
 3. Build
 
-    > - `mvn clean package`  
+    > - `mvn clean package -Dmaven.test.skip=true`  
 4. Start 
     * `mvn --projects dubbo-admin-server spring-boot:run`  
     OR

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -34,7 +34,7 @@
 2. 在 `dubbo-admin-server/src/main/resources/application.properties`中指定注册中心地址
 3. 构建
 
-    > - `mvn clean package`  
+    > - `mvn clean package -Dmaven.test.skip=true`  
 4. 启动 
    * `mvn --projects dubbo-admin-server spring-boot:run`   
    或者   


### PR DESCRIPTION
Test case contain code for various registries that will cause the test to fail and therefore cannot be packaged.