### PR TITLE
support feature multi-overload methods of the same method name #743

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/utils/ApiDocsDubboGenericUtil.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/utils/ApiDocsDubboGenericUtil.java
@@ -121,10 +121,7 @@ public class ApiDocsDubboGenericUtil {
             referenceConfig.setTimeout(timeout);
             referenceConfig.setVersion(version);
             referenceConfig.setGroup(group);
-            if ("org.apache.dubbo.apidocs.core.providers.IDubboDocProvider".equals(interfaceName)) {
-                referenceConfig.setVersion("v1");
-                referenceConfig.setGroup("apiDocsGroup");
-            }
+
             referenceConfig.setApplication(application);
             if (address.startsWith("dubbo")) {
                 referenceConfig.setUrl(address);

--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/utils/ApiDocsDubboGenericUtil.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/utils/ApiDocsDubboGenericUtil.java
@@ -121,6 +121,10 @@ public class ApiDocsDubboGenericUtil {
             referenceConfig.setTimeout(timeout);
             referenceConfig.setVersion(version);
             referenceConfig.setGroup(group);
+            if ("org.apache.dubbo.apidocs.core.providers.IDubboDocProvider".equals(interfaceName)) {
+                referenceConfig.setVersion("v1");
+                referenceConfig.setGroup("apiDocsGroup");
+            }
             referenceConfig.setApplication(application);
             if (address.startsWith("dubbo")) {
                 referenceConfig.setUrl(address);

--- a/dubbo-admin-ui/package-lock.json
+++ b/dubbo-admin-ui/package-lock.json
@@ -2434,6 +2434,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "http://nexus.enncloud.cn/repository/npm/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5470,6 +5480,13 @@
         "schema-utils": "2.7.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.enncloud.cn/repository/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -7707,6 +7724,13 @@
         "object-assign": "4.1.1",
         "thenify-all": "1.6.0"
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "http://nexus.enncloud.cn/repository/npm/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11637,7 +11661,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "1.5.0",
+            "nan": "2.14.2"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -11990,7 +12018,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "1.5.0",
+            "nan": "2.14.2"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/dubbo-admin-ui/src/components/apiDocs/ApiDocs.vue
+++ b/dubbo-admin-ui/src/components/apiDocs/ApiDocs.vue
@@ -173,7 +173,8 @@ export default {
                   apiDocName: menuItem.apiDocName,
                   description: menuItem.description,
                   apiVersion: menuItem.apiVersion,
-                  apiGroup: menuItem.apiGroup
+                  apiGroup: menuItem.apiGroup,
+                  paramsDesc: menuItem.paramsDesc
                 }
               }
               menu2.apis.push(menuItem2)

--- a/dubbo-admin-ui/src/components/apiDocs/ApiDocs.vue
+++ b/dubbo-admin-ui/src/components/apiDocs/ApiDocs.vue
@@ -174,7 +174,7 @@ export default {
                   description: menuItem.description,
                   apiVersion: menuItem.apiVersion,
                   apiGroup: menuItem.apiGroup,
-                  paramsDesc: menuItem.paramsDesc
+                  paramsDesc: menuItem.paramsDesc || ''
                 }
               }
               menu2.apis.push(menuItem2)

--- a/dubbo-admin-ui/src/components/apiDocs/ApiForm.vue
+++ b/dubbo-admin-ui/src/components/apiDocs/ApiForm.vue
@@ -304,7 +304,7 @@ export default {
           params: {
             dubboIp: curVal.dubboIp,
             dubboPort: curVal.dubboPort,
-            apiName: curVal.moduleClassName + '.' + curVal.apiName
+            apiName: curVal.moduleClassName + '.' + curVal.apiName + curVal.paramsDesc
           }
         })
         .then((response) => {
@@ -421,7 +421,7 @@ export default {
           methodName: this.formItemMethodName,
           registryCenterUrl: this.formItemRegistryCenterUrl,
           version: this.apiInfoData.apiVersion || '',
-          group: this.apiInfoData.apiGroup || ''
+          group: this.apiInfoData.apiGroup || '',
         },
         headers: {
           'Content-Type': 'application/json; charset=UTF-8'


### PR DESCRIPTION
## What is the purpose of the change

#743 
1. Dubbo Admin can load api docs list
2. Dubbo Admin can load api information

## Brief changelog

1. Set dubbo ReferenceConfig `org.apache.dubbo.apidocs.core.providers.IDubboDocProvider` 
version=apiDocsGroup & group=v1
2. ApiDocs.vue&ApiForm.vue pass paramsDesc to Dubbo Admin Server.

## Verifying this change

Dubbo Admin Verison : 0.3.0-SNAPSHOT
Dubbo API Docs Version: 2.7.8.3-SNAPSHOT


