### PR TITLE
fix ServiceTestUtil NPE

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/common/util/ServiceTestUtil.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/common/util/ServiceTestUtil.java
@@ -86,7 +86,7 @@ public class ServiceTestUtil {
 
     private static TypeDefinition findTypeDefinition(ServiceDefinition serviceDefinition, String type) {
         return serviceDefinition.getTypes().stream()
-                .filter(t -> t.getType().equals(type))
+                .filter(t -> type.equals(t.getType()))
                 .findFirst().orElse(new TypeDefinition(type));
     }
 


### PR DESCRIPTION
```
java.lang.NullPointerException: null
	at org.apache.dubbo.admin.common.util.ServiceTestUtil.lambda$findTypeDefinition$0(ServiceTestUtil.java:89) ~[classes/:na]
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174) ~[na:1.8.0_181]
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1359) ~[na:1.8.0_181]
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126) ~[na:1.8.0_181]
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498) ~[na:1.8.0_181]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485) ~[na:1.8.0_181]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_181]
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152) ~[na:1.8.0_181]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_181]
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:464) ~[na:1.8.0_181]
	at org.apache.dubbo.admin.common.util.ServiceTestUtil.findTypeDefinition(ServiceTestUtil.java:90) ~[classes/:na]
	at org.apache.dubbo.admin.common.util.ServiceTestUtil.generateType(ServiceTestUtil.java:159) ~[classes/:na]
	at org.apache.dubbo.admin.common.util.ServiceTestUtil.generateParameterTypes(ServiceTestUtil.java:81) ~[classes/:na]
	at org.apache.dubbo.admin.common.util.ServiceTestUtil.generateMethodMeta(ServiceTestUtil.java:58) ~[classes/:na]
	at org.apache.dubbo.admin.controller.ServiceTestController.methodDetail(ServiceTestController.java:79) ~[classes/:na]
```

```java
serviceDefinition.getTypes().stream()
                .filter(t -> t.getType().equals(type))
```  
```t.getType()``` null values may exist

![image](https://user-images.githubusercontent.com/5037807/130717693-7f3fc71d-183d-4216-b22b-806121252ead.png)
