### PR TITLE
ZookeeperMetaDataCollector init method add zk digest acl support

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/registry/metadata/impl/ZookeeperMetaDataCollector.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/registry/metadata/impl/ZookeeperMetaDataCollector.java
@@ -53,7 +53,15 @@ public class ZookeeperMetaDataCollector implements MetaDataCollector {
             group = Constants.PATH_SEPARATOR + group;
         }
         root = group;
-        client = CuratorFrameworkFactory.newClient(url.getAddress(), new ExponentialBackoffRetry(1000, 3));
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.
+                builder()
+                .connectString(url.getAddress())
+                .retryPolicy(new ExponentialBackoffRetry(1000, 3));
+        String userInformation = url.getUserInformation();
+        if (userInformation != null && userInformation.length() > 0) {
+            builder = builder.authorization("digest", userInformation.getBytes());
+        }
+        client = builder.build();
         client.start();
     }
 


### PR DESCRIPTION
The branch of 0.2.0 is master-0.2.0. If your PR is to solve the problem of 0.2.0, please submit the PR to it.
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

1. ZookeeperMetaDataCollector#init() add digest authorization support. If not set, can be throw NoAuth Exception when use instance discovery and zk node set acl

## Brief changelog


## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
* [ ] Run `mvn clean compile --batch-mode -DskipTests=false -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true to make sure basic checks pass.
