### PR TITLE
fix: enchace dubbo version to 3.1.6 to fix error in start up

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/registry/mapping/impl/ZookeeperServiceMapping.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/registry/mapping/impl/ZookeeperServiceMapping.java
@@ -53,7 +53,7 @@ public class ZookeeperServiceMapping implements ServiceMapping {
 
     @Override
     public void listenerAll() {
-        zkClient.create(MAPPING_PATH, false);
+        zkClient.create(MAPPING_PATH, false, false);
         List<String> services = zkClient.addChildListener(MAPPING_PATH, (path, currentChildList) -> {
             for (String child : currentChildList) {
                 if (anyServices.add(child)) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<revision>0.5.0-SNAPSHOT</revision>
 		<main.basedir>${project.basedir}</main.basedir>
 		<commons-lang3-version>3.7</commons-lang3-version>
-		<dubbo-version>3.1.2</dubbo-version>
+		<dubbo-version>3.1.6</dubbo-version>
 		<fastjson-version>1.2.83</fastjson-version>
 		<springfox-swagger-version>2.9.2</springfox-swagger-version>
 		<jacoco-version>0.8.2</jacoco-version>


### PR DESCRIPTION
## What is the purpose of the change

close [dubbo #11635](https://github.com/apache/dubbo/issues/11635)

## Brief changelog

- enchace dubbo version from 3.1.2 to 3.1.6

## Verifying this change

dubbo 3.1.2:
![image](https://user-images.githubusercontent.com/56248584/220947464-fdffdbb9-4520-4592-8d73-b73b695fd712.png)

dubbo 3.1.6:
![image](https://user-images.githubusercontent.com/56248584/220947705-aa492564-bead-4ee1-b137-b998632bcabe.png)



Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
* [ ] Run `mvn clean compile --batch-mode -DskipTests=false -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true to make sure basic checks pass.
