### PR TITLE
set qps and burst for rest config

### DIFF
--- a/pkg/authority/config/options.go
+++ b/pkg/authority/config/options.go
@@ -46,6 +46,11 @@ type Options struct {
 	// TODO remove EnableOIDCCheck
 	EnableOIDCCheck      bool
 	ResourcelockIdentity string
+
+	// Qps for rest config
+	RestConfigQps int
+	// Burst for rest config
+	RestConfigBurst int
 }
 
 func NewOptions() *Options {
@@ -64,6 +69,8 @@ func NewOptions() *Options {
 		IsKubernetesConnected: false,
 		EnableOIDCCheck:       true,
 		ResourcelockIdentity:  GetStringEnv("POD_NAME", GetDefaultResourcelockIdentity()),
+		RestConfigQps:         50,
+		RestConfigBurst:       100,
 	}
 }
 
@@ -78,6 +85,8 @@ func (o *Options) FillFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.InPodEnv, "in-pod-env", false, "dubbo run in pod environment")
 	flags.BoolVar(&o.IsKubernetesConnected, "is-kubernetes-connected", false, "dubbo connected with kubernetes")
 	flags.BoolVar(&o.EnableOIDCCheck, "enable-oidc-check", false, "dubbo enable OIDC check")
+	flags.IntVar(&o.RestConfigQps, "rest-config-qps", 50, "qps for rest config")
+	flags.IntVar(&o.RestConfigBurst, "rest-config-burst", 100, "burst for rest config")
 }
 
 func (o *Options) Validate() []error {

--- a/pkg/authority/k8s/client.go
+++ b/pkg/authority/k8s/client.go
@@ -100,6 +100,9 @@ func (c *ClientImpl) Init(options *config.Options) bool {
 		}
 	}
 
+	// set qps and burst for rest config
+	config.QPS = float32(c.options.RestConfigQps)
+	config.Burst = c.options.RestConfigBurst
 	// creates the clientset
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
## What is the purpose of the change

set qps and burst for rest config

## Brief changelog
1. default rest config qps is 5, and burst is 10 
2. set qps with default  50, and default burst to 100.


## Verifying this change
./authority --rest-config-qps=100 --rest-config-burst=200


Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
* [ ] Run `mvn clean compile --batch-mode -DskipTests=false -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true to make sure basic checks pass.
