### PR TITLE
Prometheus http_sd discovery and unit test

### DIFF
--- a/pkg/admin/model/monitor.go
+++ b/pkg/admin/model/monitor.go
@@ -19,3 +19,8 @@ type Response struct {
 	Status int    `json:"status"`
 	Data   string `json:"data"`
 }
+
+type Target struct {
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels"`
+}

--- a/pkg/admin/services/monitor_service.go
+++ b/pkg/admin/services/monitor_service.go
@@ -16,8 +16,9 @@
 package services
 
 import (
-	"github.com/apache/dubbo-admin/pkg/admin/model"
 	"net/http"
+
+	"github.com/apache/dubbo-admin/pkg/admin/model"
 )
 
 type MonitorService interface {

--- a/pkg/admin/services/prometheus_service_impl.go
+++ b/pkg/admin/services/prometheus_service_impl.go
@@ -46,6 +46,10 @@ func (p *PrometheusServiceImpl) PromDiscovery(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	// Reduce the call chain and improve performance.
 	proAddr, err := providerServiceImpl.findAddresses()
+	if err != nil {
+		logger.Sugar().Errorf("Error provider findAddresses: %v\n", err)
+		return err
+	}
 	var targets []string
 	for i := 0; i < len(proAddr); i++ {
 		targets = append(targets, util.GetDiscoveryPath(proAddr[i]))

--- a/pkg/admin/services/prometheus_service_impl.go
+++ b/pkg/admin/services/prometheus_service_impl.go
@@ -17,6 +17,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -28,16 +29,46 @@ import (
 	"github.com/apache/dubbo-admin/pkg/admin/config"
 	"github.com/apache/dubbo-admin/pkg/admin/constant"
 	"github.com/apache/dubbo-admin/pkg/admin/model"
+	"github.com/apache/dubbo-admin/pkg/admin/util"
 	"github.com/apache/dubbo-admin/pkg/logger"
 	"github.com/apache/dubbo-admin/pkg/monitor/prometheus"
 )
 
 var (
-	providerService ProviderService = &ProviderServiceImpl{}
-	consumerService ConsumerService = &ConsumerServiceImpl{}
+	providerService     ProviderService = &ProviderServiceImpl{}
+	consumerService     ConsumerService = &ConsumerServiceImpl{}
+	providerServiceImpl                 = &ProviderServiceImpl{}
 )
 
 type PrometheusServiceImpl struct{}
+
+func (p *PrometheusServiceImpl) PromDiscovery(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	// Reduce the call chain and improve performance.
+	proAddr, err := providerServiceImpl.findAddresses()
+	var targets []string
+	for i := 0; i < len(proAddr); i++ {
+		targets = append(targets, util.GetDiscoveryPath(proAddr[i]))
+	}
+	filterCon := make(map[string]string)
+	filterCon[constant.CategoryKey] = constant.ConsumersCategory
+	servicesMap, err := util.FilterFromCategory(filterCon)
+	if err != nil {
+		logger.Sugar().Errorf("Error filter category: %v\n", err)
+		return err
+	}
+	for _, url := range servicesMap {
+		targets = append(targets, util.GetDiscoveryPath(url.Location))
+	}
+	target := []model.Target{
+		{
+			Targets: targets,
+			Labels:  map[string]string{},
+		},
+	}
+	err = json.NewEncoder(w).Encode(target)
+	return err
+}
 
 func (p *PrometheusServiceImpl) ClusterMetrics() ([]model.Response, error) {
 	res := make([]model.Response, 5)

--- a/pkg/admin/services/prometheus_service_impl_test.go
+++ b/pkg/admin/services/prometheus_service_impl_test.go
@@ -18,12 +18,8 @@
 package services
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/common"
 	"encoding/json"
 	"fmt"
-	"github.com/apache/dubbo-admin/pkg/admin/cache"
-	"github.com/apache/dubbo-admin/pkg/admin/constant"
-	"github.com/apache/dubbo-admin/pkg/admin/model"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +27,12 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/apache/dubbo-admin/pkg/admin/cache"
+	"github.com/apache/dubbo-admin/pkg/admin/constant"
+	"github.com/apache/dubbo-admin/pkg/admin/model"
+
+	"dubbo.apache.org/dubbo-go/v3/common"
 )
 
 var (

--- a/pkg/admin/services/prometheus_service_impl_test.go
+++ b/pkg/admin/services/prometheus_service_impl_test.go
@@ -35,9 +35,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 )
 
-var (
-	prometheusService MonitorService = &PrometheusServiceImpl{}
-)
+var prometheusService MonitorService = &PrometheusServiceImpl{}
 
 type args struct {
 	address []string
@@ -51,8 +49,8 @@ type test struct {
 }
 
 func initCache(test []test) {
-	proservice := &sync.Map{}
-	conservice := &sync.Map{}
+	proService := &sync.Map{}
+	conService := &sync.Map{}
 	// protest1
 	protest1QueryParams := url.Values{
 		constant.ApplicationKey: {"protest1QueryParams"},
@@ -90,18 +88,18 @@ func initCache(test []test) {
 		common.WithParams(contest2QueryParams),
 		common.WithLocation(test[0].args.address[3]),
 	)
-	proservice.Store("providers", map[string]*common.URL{
+	proService.Store("providers", map[string]*common.URL{
 		"protest1": protest1,
 		"protest2": protest2,
 	})
 
-	conservice.Store("consumers", map[string]*common.URL{
+	conService.Store("consumers", map[string]*common.URL{
 		"contest1": contest1,
 		"contest2": contest2,
 	})
 
-	cache.InterfaceRegistryCache.Store(constant.ProvidersCategory, proservice)
-	cache.InterfaceRegistryCache.Store(constant.ConsumersCategory, conservice)
+	cache.InterfaceRegistryCache.Store(constant.ProvidersCategory, proService)
+	cache.InterfaceRegistryCache.Store(constant.ConsumersCategory, conService)
 }
 
 // Simulate Prometheus to send requests for http_sd service discovery.
@@ -120,7 +118,6 @@ func initPromClient(url string) ([]byte, error) {
 
 // Simulate Prometheus to periodically send requests to admin to realize http_ds service discovery.
 func TestPrometheusServiceImpl_PromDiscovery(t *testing.T) {
-
 	tests := []test{
 		{
 			name: "TEST",

--- a/pkg/admin/services/prometheus_service_impl_test.go
+++ b/pkg/admin/services/prometheus_service_impl_test.go
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+
+//	http://www.apache.org/licenses/LICENSE-2.0
+
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"encoding/json"
+	"fmt"
+	"github.com/apache/dubbo-admin/pkg/admin/cache"
+	"github.com/apache/dubbo-admin/pkg/admin/constant"
+	"github.com/apache/dubbo-admin/pkg/admin/model"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+var (
+	prometheusService MonitorService = &PrometheusServiceImpl{}
+)
+
+type args struct {
+	address []string
+}
+
+type test struct {
+	name    string
+	args    args
+	want    []model.Target
+	wantErr error
+}
+
+func initCache(test []test) {
+	proservice := &sync.Map{}
+	conservice := &sync.Map{}
+	// protest1
+	protest1QueryParams := url.Values{
+		constant.ApplicationKey: {"protest1QueryParams"},
+	}
+	protest1, _ := common.NewURL(test[0].args.address[0],
+		common.WithProtocol(constant.AdminProtocol),
+		common.WithParams(protest1QueryParams),
+		common.WithLocation(test[0].args.address[0]),
+	)
+	// protest2
+	protest2QueryParams := url.Values{
+		constant.ApplicationKey: {"protest2QueryParams"},
+	}
+	protest2, _ := common.NewURL(test[0].args.address[1],
+		common.WithProtocol(constant.AdminProtocol),
+		common.WithParams(protest2QueryParams),
+		common.WithLocation(test[0].args.address[1]),
+	)
+
+	contest1QueryParams := url.Values{
+		constant.ApplicationKey: {"protest1QueryParams"},
+	}
+	// consumer test1
+	contest1, _ := common.NewURL(test[0].args.address[2],
+		common.WithProtocol(constant.AdminProtocol),
+		common.WithParams(contest1QueryParams),
+		common.WithLocation(test[0].args.address[2]),
+	)
+	// consumer test2
+	contest2QueryParams := url.Values{
+		constant.ApplicationKey: {"protest2QueryParams"},
+	}
+	contest2, _ := common.NewURL(test[0].args.address[3],
+		common.WithProtocol(constant.AdminProtocol),
+		common.WithParams(contest2QueryParams),
+		common.WithLocation(test[0].args.address[3]),
+	)
+	proservice.Store("providers", map[string]*common.URL{
+		"protest1": protest1,
+		"protest2": protest2,
+	})
+
+	conservice.Store("consumers", map[string]*common.URL{
+		"contest1": contest1,
+		"contest2": contest2,
+	})
+
+	cache.InterfaceRegistryCache.Store(constant.ProvidersCategory, proservice)
+	cache.InterfaceRegistryCache.Store(constant.ConsumersCategory, conservice)
+}
+
+// Simulate Prometheus to send requests for http_sd service discovery.
+func initPromClient(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// Simulate Prometheus to periodically send requests to admin to realize http_ds service discovery.
+func TestPrometheusServiceImpl_PromDiscovery(t *testing.T) {
+
+	tests := []test{
+		{
+			name: "TEST",
+			args: args{
+				address: []string{
+					"127.0.0.1:0",
+					"198.127.163.150:8080",
+					"198.127.163.153:0",
+					"198.127.163.151:0",
+				},
+			},
+			wantErr: nil,
+			want: []model.Target{
+				{
+					Labels: map[string]string{},
+					Targets: []string{
+						"127.0.0.1:22222",
+						"198.127.163.150:22222",
+						"198.127.163.153:22222",
+						"198.127.163.151:22222",
+					},
+				},
+			},
+		},
+	}
+	initCache(tests)
+	defer cache.InterfaceRegistryCache.Delete(constant.ProvidersCategory)
+	defer cache.InterfaceRegistryCache.Delete(constant.ConsumersCategory)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				err := prometheusService.PromDiscovery(w)
+				if err != nil {
+					t.Errorf("Server Start Error: %v\n", err)
+				}
+			}))
+			defer ts.Close()
+			addr := ts.URL
+			resp, err := initPromClient(addr)
+			fmt.Println(string(resp))
+			if err != nil {
+				t.Errorf("Error: %v\n", err)
+			}
+			var target []model.Target
+			err = json.Unmarshal(resp, &target)
+			if !reflect.DeepEqual(target, tt.want) {
+				t.Errorf("PromDiscovery() got = %v, want %v", target, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/admin/services/prometheus_service_impl_test.go
+++ b/pkg/admin/services/prometheus_service_impl_test.go
@@ -162,7 +162,7 @@ func TestPrometheusServiceImpl_PromDiscovery(t *testing.T) {
 				t.Errorf("Error: %v\n", err)
 			}
 			var target []model.Target
-			err = json.Unmarshal(resp, &target)
+			_ = json.Unmarshal(resp, &target)
 			if !reflect.DeepEqual(target, tt.want) {
 				t.Errorf("PromDiscovery() got = %v, want %v", target, tt.want)
 			}

--- a/pkg/admin/util/monitor_utils.go
+++ b/pkg/admin/util/monitor_utils.go
@@ -11,17 +11,16 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package services
+// limitations under the License.
 
-package services
+package util
 
-import (
-	"github.com/apache/dubbo-admin/pkg/admin/model"
-	"net/http"
-)
+import "strings"
 
-type MonitorService interface {
-	FlowMetrics() ([]model.Response, error)    // Traffic overview
-	ClusterMetrics() ([]model.Response, error) // Cluster overview
-	PromDiscovery(w http.ResponseWriter) error // prometheus http_sd discovery
+func GetDiscoveryPath(address string) string {
+	if strings.Contains(address, ":") {
+		index := strings.Index(address, ":")
+		return address[0:index] + ":22222"
+	}
+	return address + ":22222"
 }

--- a/pkg/admin/util/monitor_utils_test.go
+++ b/pkg/admin/util/monitor_utils_test.go
@@ -11,17 +11,45 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package services
+// limitations under the License.
 
-package services
+package util
 
 import (
-	"github.com/apache/dubbo-admin/pkg/admin/model"
-	"net/http"
+	"reflect"
+	"testing"
 )
 
-type MonitorService interface {
-	FlowMetrics() ([]model.Response, error)    // Traffic overview
-	ClusterMetrics() ([]model.Response, error) // Cluster overview
-	PromDiscovery(w http.ResponseWriter) error // prometheus http_sd discovery
+func TestGetDiscoveryPath(t *testing.T) {
+	type args struct {
+		address string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "RightTest1",
+			args: args{
+				address: "127.0.0.1:0",
+			},
+			want: "127.0.0.1:22222",
+		},
+		{
+			name: "RightTest2",
+			args: args{
+				address: "192.168.127.153",
+			},
+			want: "192.168.127.153:22222",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := GetDiscoveryPath(tt.args.address)
+			if !reflect.DeepEqual(path, tt.want) {
+				t.Errorf("GetDiscoveryPath() = %v, want %v", path, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
why 22222 int pkg/admin/util/monitor_utils.go?
ans: After communicating with the relevant person in charge, he asked me to write 22222 to death first, and the follow-up monitoring port will be put into the registration center.