### PR TITLE
Modify small bugs in unit tests

### DIFF
--- a/pkg/admin/services/prometheus_service_impl_test.go
+++ b/pkg/admin/services/prometheus_service_impl_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 
@@ -163,6 +164,14 @@ func TestPrometheusServiceImpl_PromDiscovery(t *testing.T) {
 			}
 			var target []model.Target
 			_ = json.Unmarshal(resp, &target)
+			for i := 0; i < len(target); i++ {
+				gots := target[i].Targets
+				targets := tt.want[i].Targets
+				sort.Strings(gots)
+				sort.Strings(targets)
+				target[i].Targets = gots
+				tt.want[i].Targets = targets
+			}
 			if !reflect.DeepEqual(target, tt.want) {
 				t.Errorf("PromDiscovery() got = %v, want %v", target, tt.want)
 			}


### PR DESCRIPTION
The relevant information of consumers and service providers in dubbo admin is saved in the form of map[string]common.URL. The underlying implementation principle of map determines that it may be out of order, which is different from the string array in tt.want The order is different, so when comparing, sometimes it can succeed, and sometimes it will fail. So sort and then compare.