### PR TITLE
fix:Fix init of `ServiceMapping` when metadata center uses nacos.

### DIFF
--- a/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/config/ConfigCenter.java
+++ b/dubbo-admin-server/src/main/java/org/apache/dubbo/admin/config/ConfigCenter.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.admin.common.util.Constants;
 import org.apache.dubbo.admin.registry.config.GovernanceConfiguration;
 import org.apache.dubbo.admin.registry.mapping.AdminMappingListener;
 import org.apache.dubbo.admin.registry.mapping.ServiceMapping;
+import org.apache.dubbo.admin.registry.mapping.impl.NacosServiceMapping;
 import org.apache.dubbo.admin.registry.mapping.impl.NoOpServiceMapping;
 import org.apache.dubbo.admin.registry.metadata.MetaDataCollector;
 import org.apache.dubbo.admin.service.impl.InstanceRegistryCache;
@@ -203,7 +204,11 @@ public class ConfigCenter {
         MappingListener mappingListener = new AdminMappingListener(serviceDiscovery, instanceRegistryCache);
         serviceMapping = ExtensionLoader.getExtensionLoader(ServiceMapping.class).getExtension(metadataUrl.getProtocol());
         serviceMapping.addMappingListener(mappingListener);
-        serviceMapping.init(metadataUrl);
+        if (serviceMapping instanceof NacosServiceMapping) {
+            serviceMapping.init(registryUrl);
+        } else {
+            serviceMapping.init(metadataUrl);
+        }
         return serviceMapping;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

当将`Nacos`用作注册中心和元数据中心时，并且元数据中心与注册中心的地址不相同时，会导致数据加载出现问题。

根据当前`NacosServiceMapping`的实现方式，它应该从注册中心的地址查询服务信息，而不是使用配置的元数据中心地址。

When `Nacos` is used as the registration center and metadata center, and the addresses of the metadata center and the registration center are different, it will cause problems in data loading.

According to the current implementation of `NacosServiceMapping`, it should query service information from the registry address instead of using the configured metadata center address.

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
* [ ] Run `mvn clean compile --batch-mode -DskipTests=false -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true to make sure basic checks pass.
