### PR TITLE
Fix missing apiserver module

### DIFF
--- a/charts/admin-stack/charts/dubbo-admin/templates/_helpers.tpl
+++ b/charts/admin-stack/charts/dubbo-admin/templates/_helpers.tpl
@@ -85,3 +85,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.nameTest }}
 {{- end }}
 {{- end }}
+
+{{- define "dubbo-admin.rbac.apiVersion" -}}
+{{- if $.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" }}
+{{- else }}
+{{- print "rbac.authorization.k8s.io/v1beta1" }}
+{{- end }}
+{{- end }}
+
+{{- define "dubbo-admin.podDisruptionBudget.apiVersion" -}}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+{{- print "policy/v1" }}
+{{- else }}
+{{- print "policy/v1beta1" }}
+{{- end }}
+{{- end }}

--- a/charts/admin-stack/charts/dubbo-admin/templates/rolebinding.yaml
+++ b/charts/admin-stack/charts/dubbo-admin/templates/rolebinding.yaml
@@ -17,8 +17,8 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "dubbo-admin.fullname" . }}
-  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "dubbo-admin.serviceAccountName" . }}
     namespace: {{ include "dubbo-admin.namespace" . }}
+{{- end }}

--- a/charts/admin-stack/charts/dubbo-admin/values.yaml
+++ b/charts/admin-stack/charts/dubbo-admin/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: apache/dubbo-admin
   ##
   ##
-  tag: "0.5.0"
+  tag: "0.6.0"
   ##
   ##
   debug: false


### PR DESCRIPTION
```
Error: INSTALLATION FAILED: template: dubbo-admin/templates/role.yaml:2:15: executing "dubbo-admin/templates/role.yaml" at <include "dubbo-admin.rbac.apiVersion" .>: error calling include: template: no template "dubbo-admin.rbac.apiVersion" associated with template "gotpl"
```
```
Error: INSTALLATION FAILED: template: dubbo-admin/templates/pdb.yaml:1:15: executing "dubbo-admin/templates/pdb.yaml" at <include "dubbo-admin.podDisruptionBudget.apiVersion" .>: error calling include: template: no template "dubbo-admin.podDisruptionBudget.apiVersion" associated with template "gotpl"
```
