### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-core to 

### DIFF
--- a/dubbo-admin-server/pom.xml
+++ b/dubbo-admin-server/pom.xml
@@ -263,7 +263,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-core 1.2.3
- [MPS-2022-12411](https://www.oscs1024.com/hd/MPS-2022-12411)


### What did I do？
Upgrade ch.qos.logback:logback-core from 1.2.3 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS