### PR TITLE
修复jdk21编译lombok版本过低报错

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <dubbo-mock-version>3.0.0</dubbo-mock-version>
         <mybatis-plus-boot-version>3.4.2</mybatis-plus-boot-version>
         <curator-test-veriosn>2.12.0</curator-test-veriosn>
+        <lombok.version>1.18.30</lombok.version>
 
         <maven-checkstyle-plugin-version>3.0.0</maven-checkstyle-plugin-version>
         <spring-boot-version>2.3.12.RELEASE</spring-boot-version>
@@ -130,6 +131,11 @@
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-test</artifactId>
                 <version>${curator-test-veriosn}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What is the purpose of the change

修复jdk21编译lombok版本过低报错

## Brief changelog

jdk21编译需要lombok版本1.18.30
否则dubbo-admin-server报错:java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'

## Verifying this change

XXXX


