### PR TITLE
Changed the mirror for certificate expiration in package-lock.json file

### DIFF
--- a/dubbo-admin-ui/package-lock.json
+++ b/dubbo-admin-ui/package-lock.json
@@ -1209,7 +1209,7 @@
     },
     "@sphinxxxx/color-conversion": {
       "version": "2.2.2",
-      "resolved": "https://registry.npm.taobao.org/@sphinxxxx/color-conversion/download/@sphinxxxx/color-conversion-2.2.2.tgz",
+      "resolved": "http://registry.npmmirror.com/@sphinxxxx/color-conversion/download/@sphinxxxx/color-conversion-2.2.2.tgz",
       "integrity": "sha1-A+zCknnjwMgy9hhaW/o0l4WKyMo="
     },
     "@types/color-name": {
@@ -1930,7 +1930,7 @@
     },
     "ace-builds": {
       "version": "1.4.12",
-      "resolved": "https://registry.npm.taobao.org/ace-builds/download/ace-builds-1.4.12.tgz",
+      "resolved": "http://registry.npmmirror.com/ace-builds/download/ace-builds-1.4.12.tgz",
       "integrity": "sha1-iI76OG429DRfQLUjP8xP5MWI+uc="
     },
     "acorn": {
@@ -1969,7 +1969,7 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-6.12.6.tgz?cache=0&sync_timestamp=1608146063236&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fajv%2Fdownload%2Fajv-6.12.6.tgz",
+      "resolved": "http://registry.npmmirror.com/ajv/download/ajv-6.12.6.tgz?cache=0&sync_timestamp=1608146063236&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fajv%2Fdownload%2Fajv-6.12.6.tgz",
       "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "requires": {
         "fast-deep-equal": "3.1.3",
@@ -5386,7 +5386,7 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-3.1.3.tgz?cache=0&sync_timestamp=1591599604977&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffast-deep-equal%2Fdownload%2Ffast-deep-equal-3.1.3.tgz",
+      "resolved": "http://registry.npmmirror.com/fast-deep-equal/download/fast-deep-equal-3.1.3.tgz?cache=0&sync_timestamp=1591599604977&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffast-deep-equal%2Fdownload%2Ffast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
     },
     "fast-glob": {
@@ -6894,7 +6894,7 @@
     },
     "javascript-natural-sort": {
       "version": "0.7.1",
-      "resolved": "https://registry.npm.taobao.org/javascript-natural-sort/download/javascript-natural-sort-0.7.1.tgz",
+      "resolved": "http://registry.npmmirror.com/javascript-natural-sort/download/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
     },
     "javascript-stringify": {
@@ -6932,7 +6932,7 @@
     },
     "jmespath": {
       "version": "0.15.0",
-      "resolved": "https://registry.npm.taobao.org/jmespath/download/jmespath-0.15.0.tgz",
+      "resolved": "http://registry.npmmirror.com/jmespath/download/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-message": {
@@ -6991,12 +6991,12 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
+      "resolved": "http://registry.npmmirror.com/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/json-source-map/download/json-source-map-0.6.1.tgz",
+      "resolved": "http://registry.npmmirror.com/json-source-map/download/json-source-map-0.6.1.tgz",
       "integrity": "sha1-4LH29M4Tqa1X4q4WWiTQbmLHmg8="
     },
     "json-stable-stringify-without-jsonify": {
@@ -7028,7 +7028,7 @@
     },
     "jsoneditor": {
       "version": "9.1.5",
-      "resolved": "https://registry.npm.taobao.org/jsoneditor/download/jsoneditor-9.1.5.tgz",
+      "resolved": "http://registry.npmmirror.com/jsoneditor/download/jsoneditor-9.1.5.tgz",
       "integrity": "sha1-GQo2bKUXEyGhIKp0YMQ5i1PyucE=",
       "requires": {
         "ace-builds": "1.4.12",
@@ -7670,7 +7670,7 @@
     },
     "mobius1-selectr": {
       "version": "2.4.13",
-      "resolved": "https://registry.npm.taobao.org/mobius1-selectr/download/mobius1-selectr-2.4.13.tgz",
+      "resolved": "http://registry.npmmirror.com/mobius1-selectr/download/mobius1-selectr-2.4.13.tgz",
       "integrity": "sha1-ABnf2fmEhA1uQPcGg6s+x4zjtd8="
     },
     "move-concurrently": {
@@ -8388,7 +8388,7 @@
     },
     "picomodal": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/picomodal/download/picomodal-3.0.0.tgz",
+      "resolved": "http://registry.npmmirror.com/picomodal/download/picomodal-3.0.0.tgz",
       "integrity": "sha1-+s0w9PvzSoCcHgTqUl8ATzmcC4I="
     },
     "pify": {
@@ -10034,7 +10034,7 @@
     },
     "simple-json-repair": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/simple-json-repair/download/simple-json-repair-1.1.0.tgz",
+      "resolved": "http://registry.npmmirror.com/simple-json-repair/download/simple-json-repair-1.1.0.tgz",
       "integrity": "sha1-h6tv4BhGh9MsKZa7gidW2oMih9Q="
     },
     "simple-swizzle": {
@@ -11395,7 +11395,7 @@
     },
     "vanilla-picker": {
       "version": "2.11.0",
-      "resolved": "https://registry.npm.taobao.org/vanilla-picker/download/vanilla-picker-2.11.0.tgz?cache=0&sync_timestamp=1605223236645&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvanilla-picker%2Fdownload%2Fvanilla-picker-2.11.0.tgz",
+      "resolved": "http://registry.npmmirror.com/vanilla-picker/download/vanilla-picker-2.11.0.tgz?cache=0&sync_timestamp=1605223236645&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvanilla-picker%2Fdownload%2Fvanilla-picker-2.11.0.tgz",
       "integrity": "sha1-ow1xdEAthGuXx0+B4Avng3oUDWQ=",
       "requires": {
         "@sphinxxxx/color-conversion": "2.2.2"
@@ -11506,7 +11506,7 @@
     },
     "vue-json-viewer": {
       "version": "2.2.16",
-      "resolved": "https://registry.npm.taobao.org/vue-json-viewer/download/vue-json-viewer-2.2.16.tgz",
+      "resolved": "http://registry.npmmirror.com/vue-json-viewer/download/vue-json-viewer-2.2.16.tgz",
       "integrity": "sha1-YCP02C2ntrBHeTIvUMFiT9kBxXA=",
       "requires": {
         "clipboard": "2.0.6",


### PR DESCRIPTION
## What is the purpose of the change

Every time I use `npm install` I get an error
<img width="843" alt="Snipaste_2024-09-16_01-34-04" src="https://github.com/user-attachments/assets/84eae49a-67e0-4209-93e5-4fcd47dde521">
Even if I run `npm install --registry=http://registry.npmmirror.com`it will also report an error and change `https://registry.npm.taobao.org`in`package-lock.json`to change it to not have this problem

## Verifying this change

replace https://registry.npm.taobao.org to http://registry.npmmirror.com in package-lock.json

