### PR TITLE
ci(makefile): add makefile for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Continues Integration
+name: dubbo-admin ci
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,59 +24,62 @@ on:
       - develop
 
 jobs:
-  unit-test:
-    name: Go Test
+  license-check:
+    name: License Check
     runs-on: ubuntu-latest
     if: github.repository == 'apache/dubbo-admin'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go 1.x
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .licenserc.yaml
+          mode: check
+
+  CI:
+    name: CI (${{ matrix.os }} - Go ${{ matrix.go_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # If you want to matrix build , you can append the following list.
+      matrix:
+        go_version:
+          - "1.24"
+          - "1.23"
+        os:
+          - ubuntu-latest
+    if: github.repository == 'apache/dubbo-admin'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go_version }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Download dependencies
-        run: |
-          go mod download
-      - name: Go Test
-        run: |
-          go test ./... -gcflags=-l -coverprofile=coverage.txt -covermode=atomic
-      - name: "Upload test result"
+      - name: Cache dependencies
+        # ref: https://github.com/actions/cache/blob/main/examples.md#go---module
+        uses: actions/cache@v4
+        with:
+          # Cache, works only on Linux
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          # Cache key
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Check Code Format
+        run: make fmt && git status && [[ -z `git status -s` ]]
+      - name: Run Unit Test
+        run: make test
+      # TODO(marsevilspirit): add lint
+      - name: Upload test result
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-coverage
           path: "**/coverage.txt"
       - name: Coverage
+        # TODO(marsevilspirit): fix coverage
         run: bash <(curl -s https://codecov.io/bash)
-
-  license-check:
-    name: License Check - Go
-    runs-on: ubuntu-latest
-    if: github.repository == 'apache/dubbo-admin'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Check License Header
-        uses: apache/skywalking-eyes/header@main
-
-  go-fmt:
-    name: Go fmt
-    runs-on: ubuntu-latest
-    if: github.repository == 'apache/dubbo-admin'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Download dependencies
-        run: |
-          go mod download
-      - name: Go Fmt
-        run: |
-          go fmt ./... && git status && [[ -z `git status -s` ]]
-          # diff -u <(echo -n) <(gofmt -d -s .)

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SHELL := /usr/bin/env bash
+SHELL := bash
+.DELETE_ON_ERROR:
+.DEFAULT_GOAL := help
+.SHELLFLAGS := -eu -o pipefail -c
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-print-directory
 
-.PHONY: build-dubbo-admin
-build-dubbo-admin:
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
-	-ldflags "-X github.com/apache/dubbo-admin/pkg/version.gitTag=$(GIT_VERSION)" \
-	-o bin/dubbo-admin app/dubbo-main/main.go && cp app/dubbo-admin/dubbo-admin.yaml bin/
+.PHONY: help test fmt clean lint
+
+help:
+	@echo "Available commands:"
+	@echo "  test       - Run unit tests"
+	@echo "  clean      - Clean test generate files"
+	@echo "  fmt        - Format code"
+	@echo "  lint       - Run golangci-lint"
+
+# Run unit tests
+test: clean
+	go test ./... -gcflags=-l -coverprofile=coverage.txt -covermode=atomic
+
+fmt:
+	go fmt ./...
+
+# Clean test generate files
+clean:
+	rm -rf coverage.txt
+
+# Run golangci-lint
+lint: install-golangci-lint
+	go vet ./...
+	golangci-lint run ./... --timeout=10m
+
+install-golangci-lint:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0


### PR DESCRIPTION
**Please provide a description of this PR:**
Introduce a Makefile for CI to simplify the CI logic.

In this PR, I combined the go-test and go-fmt jobs together, because I believe that CI should have a sequence first:

1. Check code format
2. Run unit tests
3. Check code lint

If the code format fails, the CI can quickly stop, and the person who submitted the PR can make quick modifications. And so on.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [ ] Installation
- [ ] User Experience
- [ ] Dubboctl
- [ ] Console
- [ ] Core Component


**Please check any characteristics that apply to this pull request.**

