### PR TITLE
fix: add indexer before init cause npe

### DIFF
--- a/pkg/core/store/component.go
+++ b/pkg/core/store/component.go
@@ -23,7 +23,6 @@ import (
 
 	coremodel "github.com/apache/dubbo-admin/pkg/core/resource/model"
 	"github.com/apache/dubbo-admin/pkg/core/runtime"
-	"github.com/apache/dubbo-admin/pkg/core/store/index"
 )
 
 func init() {
@@ -77,13 +76,6 @@ func (sc *storeComponent) Init(ctx runtime.BuilderContext) error {
 			return err
 		}
 		sc.stores[kind] = store
-		indexers := index.IndexersRegistry().Indexers(kind)
-		if indexers == nil {
-			continue
-		}
-		if err := store.AddIndexers(indexers); err != nil {
-			return err
-		}
 		if err = store.Init(ctx); err != nil {
 			return err
 		}

--- a/pkg/core/store/index/registry.go
+++ b/pkg/core/store/index/registry.go
@@ -35,6 +35,8 @@ func IndexersRegistry() IndexerRegistry {
 }
 
 type IndexerRegistry interface {
+	// Indexers returns the indexers for the given resource kind
+	// if no indexers are registered for the resource kind, an empty map is returned
 	Indexers(model.ResourceKind) cache.Indexers
 }
 
@@ -60,7 +62,10 @@ func newIndexRegistry() MutableIndexerRegistry {
 }
 
 func (i *indexerRegistry) Indexers(k model.ResourceKind) cache.Indexers {
-	return i.rIndexers[k]
+	if indexers, exists := i.rIndexers[k]; exists && indexers != nil {
+		return indexers
+	}
+	return make(cache.Indexers)
 }
 
 func (i *indexerRegistry) Register(k model.ResourceKind, indexers cache.Indexers) {

--- a/pkg/store/dbcommon/gorm_store.go
+++ b/pkg/store/dbcommon/gorm_store.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/dubbo-admin/pkg/core/resource/model"
 	"github.com/apache/dubbo-admin/pkg/core/runtime"
 	"github.com/apache/dubbo-admin/pkg/core/store"
+	"github.com/apache/dubbo-admin/pkg/core/store/index"
 )
 
 // GormStore is a GORM-backed store implementation for Dubbo resources
@@ -64,6 +65,11 @@ func (gs *GormStore) Init(_ runtime.BuilderContext) error {
 	// Use Scopes to set the table name dynamically for migration
 	if err := db.Scopes(TableScope(gs.kind.ToString())).AutoMigrate(&ResourceModel{}); err != nil {
 		return fmt.Errorf("failed to migrate schema for %s: %w", gs.kind.ToString(), err)
+	}
+	// Register indexers for the resource kind
+	indexers := index.IndexersRegistry().Indexers(gs.kind)
+	if err := gs.AddIndexers(indexers); err != nil {
+		return err
 	}
 
 	// Rebuild indices from existing data in the database

--- a/pkg/store/memory/factory.go
+++ b/pkg/store/memory/factory.go
@@ -35,6 +35,6 @@ func (sf *storeFactory) Support(s storecfg.Type) bool {
 	return s == storecfg.Memory
 }
 
-func (sf *storeFactory) New(_ coremodel.ResourceKind, _ *storecfg.Config) (store.ManagedResourceStore, error) {
-	return NewMemoryResourceStore(), nil
+func (sf *storeFactory) New(rk coremodel.ResourceKind, _ *storecfg.Config) (store.ManagedResourceStore, error) {
+	return NewMemoryResourceStore(rk), nil
 }

--- a/pkg/store/memory/store.go
+++ b/pkg/store/memory/store.go
@@ -29,19 +29,22 @@ import (
 	coremodel "github.com/apache/dubbo-admin/pkg/core/resource/model"
 	"github.com/apache/dubbo-admin/pkg/core/runtime"
 	"github.com/apache/dubbo-admin/pkg/core/store"
+	"github.com/apache/dubbo-admin/pkg/core/store/index"
 )
 
 type resourceStore struct {
+	rk         coremodel.ResourceKind
 	storeProxy cache.Indexer
 }
 
 var _ store.ManagedResourceStore = &resourceStore{}
 
-func NewMemoryResourceStore() store.ManagedResourceStore {
-	return &resourceStore{}
+func NewMemoryResourceStore(rk coremodel.ResourceKind) store.ManagedResourceStore {
+	return &resourceStore{rk: rk}
 }
 
 func (rs *resourceStore) Init(_ runtime.BuilderContext) error {
+	indexers := index.IndexersRegistry().Indexers(rs.rk)
 	rs.storeProxy = cache.NewIndexer(
 		func(obj interface{}) (string, error) {
 			r, ok := obj.(coremodel.Resource)
@@ -50,7 +53,7 @@ func (rs *resourceStore) Init(_ runtime.BuilderContext) error {
 			}
 			return r.ResourceKey(), nil
 		},
-		cache.Indexers{},
+		indexers,
 	)
 	return nil
 }

--- a/pkg/store/memory/store_test.go
+++ b/pkg/store/memory/store_test.go
@@ -76,7 +76,7 @@ func (mr *mockResource) String() string {
 }
 
 func TestNewMemoryResourceStore(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	assert.NotNil(t, store)
 }
 
@@ -88,7 +88,7 @@ func TestResourceStore_Init(t *testing.T) {
 }
 
 func TestResourceStore_AddAndGet(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestResourceStore_AddAndGet(t *testing.T) {
 }
 
 func TestResourceStore_Update(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestResourceStore_Update(t *testing.T) {
 }
 
 func TestResourceStore_Delete(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -193,7 +193,7 @@ func TestResourceStore_Delete(t *testing.T) {
 }
 
 func TestResourceStore_List(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestResourceStore_List(t *testing.T) {
 }
 
 func TestResourceStore_ListKeys(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -259,7 +259,7 @@ func TestResourceStore_ListKeys(t *testing.T) {
 }
 
 func TestResourceStore_Replace(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -295,7 +295,7 @@ func TestResourceStore_Replace(t *testing.T) {
 }
 
 func TestResourceStore_GetByKeys(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -331,7 +331,7 @@ func TestResourceStore_GetByKeys(t *testing.T) {
 }
 
 func TestResourceStore_ListByIndexes(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -386,7 +386,7 @@ func TestResourceStore_ListByIndexes(t *testing.T) {
 }
 
 func TestResourceStore_PageListByIndexes(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -467,7 +467,7 @@ func TestResourceStore_PageListByIndexes(t *testing.T) {
 }
 
 func TestResourceStore_MultipleIndexes(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -558,7 +558,7 @@ func TestResourceStore_MultipleIndexes(t *testing.T) {
 }
 
 func TestResourceStore_IndexKeys(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -631,7 +631,7 @@ func TestResourceStore_IndexKeys(t *testing.T) {
 }
 
 func TestResourceStore_ByIndex(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -690,7 +690,7 @@ func TestResourceStore_ByIndex(t *testing.T) {
 }
 
 func TestResourceStore_GetIndexers(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 
@@ -718,7 +718,7 @@ func TestResourceStore_GetIndexers(t *testing.T) {
 }
 
 func TestResourceStore_ListIndexFuncValues(t *testing.T) {
-	store := NewMemoryResourceStore()
+	store := NewMemoryResourceStore("TestResource")
 	err := store.Init(nil)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
**Please provide a description of this PR:**
gorm store need to add indexer before rebuilding indexes in the `Init()` method, while the memory store adds indexers after init. So the indexers initialization is assigned to each component-implemention to do.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [ ] Installation
- [ ] User Experience
- [ ] Dubboctl
- [ ] Console
- [x] Core Component


**Please check any characteristics that apply to this pull request.**

