### PR TITLE
fix(ui): update footer copyright year to 2026

### DIFF
--- a/ui-vue3/src/layout/index.vue
+++ b/ui-vue3/src/layout/index.vue
@@ -41,7 +41,7 @@
           </router-view>
         </a-layout-content>
         <a-layout-footer class="layout-footer"
-          >© 2024 The Apache Software Foundation.
+          >© 2026 The Apache Software Foundation.
         </a-layout-footer>
       </a-layout>
     </a-layout>


### PR DESCRIPTION
**Please provide a description of this PR:**
Related issue #1395 

This PR updates the footer copyright year in the Dubbo Admin UI from 2024 to 2026 to reflect the current year and maintain the site's professional appearance and accuracy.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [ ] Installation
- [x] User Experience
- [ ] Dubboctl
- [x] Console
- [ ] Core Component

**Please check any characteristics that apply to this pull request.**

- [x] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe):