### PR TITLE
Fix typos in documentation files

### DIFF
--- a/docs/server-develop.md
+++ b/docs/server-develop.md
@@ -1,6 +1,6 @@
 # admin console
 
-The architecture of microservcice based on Dubbo consists of two main components:
+The architecture of microservice based on Dubbo consists of two main components:
 
 - The **`Dubbo Admin`** can configures and monitor the data plane from a global perspective. The Dubbo Admin can be divided into two parts internally: console and control-plane
     - Console: Users can view and manage microservices using Console UI.

--- a/ui-vue3/README.md
+++ b/ui-vue3/README.md
@@ -87,7 +87,7 @@ function globalQuestion() {
 
    > Agreement: if your api's path starts with mock, you will get a mock result
 
-   1. Declear api
+   1. Declare api
 
       ```ts
       
@@ -105,7 +105,7 @@ function globalQuestion() {
 
       
 
-   2. Declear mock api
+   2. Declare mock api
 
       ```ts
       // define a mock api


### PR DESCRIPTION
Fix typos in documentation: microservcice to microservice, and Declear to Declare.