### PR TITLE
feat(eventbus): support per-subscriber async dispatch with graceful drain

### DIFF
--- a/pkg/config/app/admin.go
+++ b/pkg/config/app/admin.go
@@ -68,7 +68,7 @@ var DefaultAdminConfig = func() AdminConfig {
 	}
 }
 
-func (c *AdminConfig) Sanitize() {
+func (c AdminConfig) Sanitize() {
 	c.Engine.Sanitize()
 	for _, d := range c.Discovery {
 		d.Sanitize()
@@ -80,7 +80,7 @@ func (c *AdminConfig) Sanitize() {
 	c.Log.Sanitize()
 }
 
-func (c *AdminConfig) PreProcess() error {
+func (c AdminConfig) PreProcess() error {
 	discoveryPreProcess := func() error {
 		for _, d := range c.Discovery {
 			if err := d.PreProcess(); err != nil {
@@ -100,7 +100,7 @@ func (c *AdminConfig) PreProcess() error {
 	)
 }
 
-func (c *AdminConfig) PostProcess() error {
+func (c AdminConfig) PostProcess() error {
 	discoveryPostProcess := func() error {
 		for _, d := range c.Discovery {
 			if err := d.PostProcess(); err != nil {
@@ -120,7 +120,7 @@ func (c *AdminConfig) PostProcess() error {
 	)
 }
 
-func (c *AdminConfig) Validate() error {
+func (c AdminConfig) Validate() error {
 	if c.Log == nil {
 		c.Log = log.DefaultLogConfig()
 	} else if err := c.Log.Validate(); err != nil {

--- a/pkg/config/app/admin.go
+++ b/pkg/config/app/admin.go
@@ -175,7 +175,7 @@ func (c *AdminConfig) Validate() error {
 }
 
 // FindDiscovery finds the DiscoveryConfig by id, returns nil if not found
-func (c *AdminConfig) FindDiscovery(id string) *discovery.Config {
+func (c AdminConfig) FindDiscovery(id string) *discovery.Config {
 	for _, d := range c.Discovery {
 		if d.ID == id {
 			return d
@@ -185,7 +185,7 @@ func (c *AdminConfig) FindDiscovery(id string) *discovery.Config {
 }
 
 // Meshes return the mesh id list of discoveries
-func (c *AdminConfig) Meshes() []string {
+func (c AdminConfig) Meshes() []string {
 	return slice.Map(c.Discovery, func(index int, item *discovery.Config) string {
 		return item.ID
 	})

--- a/pkg/config/app/admin.go
+++ b/pkg/config/app/admin.go
@@ -68,7 +68,7 @@ var DefaultAdminConfig = func() AdminConfig {
 	}
 }
 
-func (c AdminConfig) Sanitize() {
+func (c *AdminConfig) Sanitize() {
 	c.Engine.Sanitize()
 	for _, d := range c.Discovery {
 		d.Sanitize()
@@ -80,7 +80,7 @@ func (c AdminConfig) Sanitize() {
 	c.Log.Sanitize()
 }
 
-func (c AdminConfig) PreProcess() error {
+func (c *AdminConfig) PreProcess() error {
 	discoveryPreProcess := func() error {
 		for _, d := range c.Discovery {
 			if err := d.PreProcess(); err != nil {
@@ -100,7 +100,7 @@ func (c AdminConfig) PreProcess() error {
 	)
 }
 
-func (c AdminConfig) PostProcess() error {
+func (c *AdminConfig) PostProcess() error {
 	discoveryPostProcess := func() error {
 		for _, d := range c.Discovery {
 			if err := d.PostProcess(); err != nil {
@@ -175,7 +175,7 @@ func (c *AdminConfig) Validate() error {
 }
 
 // FindDiscovery finds the DiscoveryConfig by id, returns nil if not found
-func (c AdminConfig) FindDiscovery(id string) *discovery.Config {
+func (c *AdminConfig) FindDiscovery(id string) *discovery.Config {
 	for _, d := range c.Discovery {
 		if d.ID == id {
 			return d
@@ -185,7 +185,7 @@ func (c AdminConfig) FindDiscovery(id string) *discovery.Config {
 }
 
 // Meshes return the mesh id list of discoveries
-func (c AdminConfig) Meshes() []string {
+func (c *AdminConfig) Meshes() []string {
 	return slice.Map(c.Discovery, func(index int, item *discovery.Config) string {
 		return item.ID
 	})

--- a/pkg/config/app/admin.go
+++ b/pkg/config/app/admin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/dubbo-admin/pkg/config/diagnostics"
 	"github.com/apache/dubbo-admin/pkg/config/discovery"
 	"github.com/apache/dubbo-admin/pkg/config/engine"
+	"github.com/apache/dubbo-admin/pkg/config/eventbus"
 	"github.com/apache/dubbo-admin/pkg/config/log"
 	"github.com/apache/dubbo-admin/pkg/config/observability"
 	"github.com/apache/dubbo-admin/pkg/config/store"
@@ -48,11 +49,14 @@ type AdminConfig struct {
 	Discovery []*discovery.Config `json:"discovery" yaml:"discovery"`
 	// Engine configuration
 	Engine *engine.Config `json:"engine" yaml:"engine"`
+	// EventBus configuration
+	EventBus *eventbus.Config `json:"eventBus,omitempty" yaml:"eventBus,omitempty"`
 }
 
 var _ = &AdminConfig{}
 
 var DefaultAdminConfig = func() AdminConfig {
+	eventBusCfg := eventbus.Default()
 	return AdminConfig{
 		Log:           log.DefaultLogConfig(),
 		Store:         store.DefaultStoreConfig(),
@@ -60,6 +64,7 @@ var DefaultAdminConfig = func() AdminConfig {
 		Observability: observability.DefaultObservabilityConfig(),
 		Diagnostics:   diagnostics.DefaultDiagnosticsConfig(),
 		Console:       console.DefaultConsoleConfig(),
+		EventBus:      &eventBusCfg,
 	}
 }
 
@@ -115,7 +120,7 @@ func (c AdminConfig) PostProcess() error {
 	)
 }
 
-func (c AdminConfig) Validate() error {
+func (c *AdminConfig) Validate() error {
 	if c.Log == nil {
 		c.Log = log.DefaultLogConfig()
 	} else if err := c.Log.Validate(); err != nil {
@@ -159,6 +164,12 @@ func (c AdminConfig) Validate() error {
 		c.Engine = engine.DefaultResourceEngineConfig()
 	} else if err := c.Engine.Validate(); err != nil {
 		return bizerror.Wrap(err, bizerror.ConfigError, "engine config validation failed")
+	}
+	if c.EventBus == nil {
+		cfg := eventbus.Default()
+		c.EventBus = &cfg
+	} else if err := c.EventBus.Validate(); err != nil {
+		return bizerror.Wrap(err, bizerror.ConfigError, "event bus config validation failed")
 	}
 	return nil
 }

--- a/pkg/console/counter/manager.go
+++ b/pkg/console/counter/manager.go
@@ -355,6 +355,10 @@ func (s *counterEventSubscriber) Name() string {
 	return s.name
 }
 
+func (s *counterEventSubscriber) AsyncEnabled() bool {
+	return false
+}
+
 func (s *counterEventSubscriber) ProcessEvent(event events.Event) error {
 	if s.handler == nil {
 		return nil

--- a/pkg/core/discovery/subscriber/instance.go
+++ b/pkg/core/discovery/subscriber/instance.go
@@ -55,6 +55,10 @@ func (s *InstanceEventSubscriber) Name() string {
 	return "Discovery-" + s.ResourceKind().ToString()
 }
 
+func (s *InstanceEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (s *InstanceEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.InstanceResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/discovery/subscriber/nacos_service.go
+++ b/pkg/core/discovery/subscriber/nacos_service.go
@@ -57,6 +57,10 @@ func (n *NacosServiceEventSubscriber) Name() string {
 	return "Nacos2Discovery-" + n.ResourceKind().ToString()
 }
 
+func (n *NacosServiceEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (n *NacosServiceEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.NacosServiceResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/discovery/subscriber/rpc_instance.go
+++ b/pkg/core/discovery/subscriber/rpc_instance.go
@@ -63,6 +63,10 @@ func (s *RPCInstanceEventSubscriber) ResourceKind() coremodel.ResourceKind {
 	return meshresource.RPCInstanceKind
 }
 
+func (s *RPCInstanceEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (s *RPCInstanceEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.RPCInstanceResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/discovery/subscriber/service_consumer_metadata.go
+++ b/pkg/core/discovery/subscriber/service_consumer_metadata.go
@@ -53,6 +53,10 @@ func (s *ServiceConsumerMetadataEventSubscriber) Name() string {
 	return "Discovery-" + s.ResourceKind().ToString()
 }
 
+func (s *ServiceConsumerMetadataEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (s *ServiceConsumerMetadataEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.ServiceConsumerMetadataResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/discovery/subscriber/service_provider_metadata.go
+++ b/pkg/core/discovery/subscriber/service_provider_metadata.go
@@ -53,6 +53,10 @@ func (s *ServiceProviderMetadataEventSubscriber) Name() string {
 	return "Discovery-" + s.ResourceKind().ToString()
 }
 
+func (s *ServiceProviderMetadataEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (s *ServiceProviderMetadataEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.ServiceProviderMetadataResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/discovery/subscriber/zk_config.go
+++ b/pkg/core/discovery/subscriber/zk_config.go
@@ -53,6 +53,10 @@ func (z *ZKConfigEventSubscriber) Name() string {
 	return "Discovery-" + z.ResourceKind().ToString()
 }
 
+func (z *ZKConfigEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (z *ZKConfigEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.ZKConfigResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/discovery/subscriber/zk_metadata.go
+++ b/pkg/core/discovery/subscriber/zk_metadata.go
@@ -53,6 +53,10 @@ func (z *ZKMetadataEventSubscriber) Name() string {
 	return "Discovery-" + z.ResourceKind().ToString()
 }
 
+func (z *ZKMetadataEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (z *ZKMetadataEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.ZKMetadataResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/engine/subscriber/runtime_instance.go
+++ b/pkg/core/engine/subscriber/runtime_instance.go
@@ -56,6 +56,10 @@ func (s *RuntimeInstanceEventSubscriber) Name() string {
 	return "Engine-" + s.ResourceKind().ToString()
 }
 
+func (s *RuntimeInstanceEventSubscriber) AsyncEnabled() bool {
+	return true
+}
+
 func (s *RuntimeInstanceEventSubscriber) ProcessEvent(event events.Event) error {
 	newObj, ok := event.NewObj().(*meshresource.RuntimeInstanceResource)
 	if !ok && event.NewObj() != nil {

--- a/pkg/core/events/async.go
+++ b/pkg/core/events/async.go
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-package eventbus
+package events
 
-type Config struct {
-	// BufferSize controls the buffer for every single event listener.
-	// If we go over buffer, additional delay may happen to various operation like insight recomputation or DDS.
-	BufferSize uint `json:"bufferSize" envconfig:"DUBBO_EVENT_BUS_BUFFER_SIZE"`
+import "sync/atomic"
+
+type AsyncSubscriber interface {
+	Subscriber
+	AsyncEnabled() bool
 }
 
-func (c Config) Validate() error {
-	return nil
-}
-
-func Default() Config {
-	return Config{
-		BufferSize: 1024,
-	}
+type subscriberState struct {
+	subscriber     Subscriber
+	async          bool
+	ch             chan Event
+	done           chan struct{}
+	closed         atomic.Bool
+	drainerStarted atomic.Bool
 }

--- a/pkg/core/events/async.go
+++ b/pkg/core/events/async.go
@@ -19,11 +19,6 @@ package events
 
 import "sync/atomic"
 
-type AsyncSubscriber interface {
-	Subscriber
-	AsyncEnabled() bool
-}
-
 type subscriberState struct {
 	subscriber     Subscriber
 	async          bool

--- a/pkg/core/events/component.go
+++ b/pkg/core/events/component.go
@@ -108,7 +108,7 @@ func (b *eventBus) Subscribe(subscriber Subscriber) error {
 	}
 	isAsync := false
 	if b.bufferSize > 0 {
-		if as, ok := subscriber.(AsyncSubscriber); ok && as.AsyncEnabled() {
+		if subscriber.AsyncEnabled() {
 			isAsync = true
 		}
 	}

--- a/pkg/core/events/component.go
+++ b/pkg/core/events/component.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 
+	eventbusconfig "github.com/apache/dubbo-admin/pkg/config/eventbus"
 	"github.com/apache/dubbo-admin/pkg/core/logger"
 	"github.com/apache/dubbo-admin/pkg/core/resource/model"
 	"github.com/apache/dubbo-admin/pkg/core/runtime"
@@ -37,10 +39,15 @@ type EventBusComponent interface {
 }
 
 var _ EventBusComponent = &eventBus{}
+var _ runtime.GracefulComponent = &eventBus{}
 
 type eventBus struct {
 	rwMutex       sync.RWMutex
-	subscriberDir map[model.ResourceKind]Subscribers
+	subscriberDir map[model.ResourceKind][]*subscriberState
+	bufferSize    int
+	started       atomic.Bool
+	stopped       atomic.Bool
+	wg            sync.WaitGroup
 }
 
 func (b *eventBus) RequiredDependencies() []runtime.ComponentType {
@@ -55,12 +62,29 @@ func (b *eventBus) Order() int {
 	return math.MaxInt
 }
 
-func (b *eventBus) Init(_ runtime.BuilderContext) error {
-	b.subscriberDir = make(map[model.ResourceKind]Subscribers)
+func (b *eventBus) Init(ctx runtime.BuilderContext) error {
+	b.subscriberDir = make(map[model.ResourceKind][]*subscriberState)
+	if cfg := ctx.Config().EventBus; cfg != nil {
+		b.bufferSize = int(cfg.BufferSize)
+	} else {
+		b.bufferSize = int(eventbusconfig.Default().BufferSize)
+	}
 	return nil
 }
 
 func (b *eventBus) Start(_ runtime.Runtime, _ <-chan struct{}) error {
+	if !b.started.CompareAndSwap(false, true) {
+		return fmt.Errorf("eventBus already started")
+	}
+	b.rwMutex.RLock()
+	for _, states := range b.subscriberDir {
+		for _, st := range states {
+			if st.async {
+				b.launchDrainer(st)
+			}
+		}
+	}
+	b.rwMutex.RUnlock()
 	return nil
 }
 
@@ -68,39 +92,82 @@ func (b *eventBus) Start(_ runtime.Runtime, _ <-chan struct{}) error {
 func (b *eventBus) Subscribe(subscriber Subscriber) error {
 	b.rwMutex.Lock()
 	defer b.rwMutex.Unlock()
-	subs, exists := b.subscriberDir[subscriber.ResourceKind()]
+	if b.stopped.Load() {
+		return fmt.Errorf("eventBus already stopped")
+	}
+	rk := subscriber.ResourceKind()
+	states, exists := b.subscriberDir[rk]
 	if !exists {
-		subs = make(Subscribers, 0)
+		states = make([]*subscriberState, 0)
 	}
 	// check name if is unique
-	for _, sub := range subs {
-		if sub.Name() == subscriber.Name() {
+	for _, st := range states {
+		if st.subscriber.Name() == subscriber.Name() {
 			return fmt.Errorf("duplicated subscriber name %s, skipped subscribing", subscriber.Name())
 		}
 	}
-	b.subscriberDir[subscriber.ResourceKind()] = append(subs, subscriber)
+	isAsync := false
+	if b.bufferSize > 0 {
+		if as, ok := subscriber.(AsyncSubscriber); ok && as.AsyncEnabled() {
+			isAsync = true
+		}
+	}
+	state := &subscriberState{
+		subscriber: subscriber,
+		async:      isAsync,
+	}
+	if isAsync {
+		state.ch = make(chan Event, b.bufferSize)
+		state.done = make(chan struct{})
+	}
+	b.subscriberDir[rk] = append(states, state)
+	if isAsync && b.started.Load() {
+		b.launchDrainer(state)
+	}
 	return nil
 }
 
 func (b *eventBus) Unsubscribe(subscriber Subscriber) error {
+	var asyncState *subscriberState
+	var drainerRunning bool
+
 	b.rwMutex.Lock()
-	defer b.rwMutex.Unlock()
 	rk := subscriber.ResourceKind()
 	name := subscriber.Name()
-	subs, exists := b.subscriberDir[rk]
+	states, exists := b.subscriberDir[rk]
 	if !exists {
+		b.rwMutex.Unlock()
 		return fmt.Errorf("no subscriber for resource %s, skipped unsubscribing", rk)
 	}
-	for i, sub := range subs {
-		if sub.Name() == name {
-			b.subscriberDir[rk] = append(subs[:i], subs[i+1:]...)
-			return nil
+	found := false
+	for i, st := range states {
+		if st.subscriber.Name() == name {
+			b.subscriberDir[rk] = append(states[:i], states[i+1:]...)
+			if st.async && st.ch != nil {
+				st.closed.Store(true)
+				close(st.ch)
+				asyncState = st
+				drainerRunning = st.drainerStarted.Load()
+			}
+			found = true
+			break
 		}
 	}
-	return fmt.Errorf("no subscriber named %s for resource %s, skipped unsubscribing", name, rk)
+	b.rwMutex.Unlock()
+	if !found {
+		return fmt.Errorf("no subscriber named %s for resource %s, skipped unsubscribing", name, rk)
+	}
+	if asyncState != nil && drainerRunning {
+		<-asyncState.done
+	}
+	return nil
 }
 
 func (b *eventBus) Send(event Event) {
+	if b.stopped.Load() {
+		return
+	}
+
 	b.rwMutex.RLock()
 	defer b.rwMutex.RUnlock()
 	var rk model.ResourceKind
@@ -109,15 +176,65 @@ func (b *eventBus) Send(event Event) {
 	} else if event.OldObj() != nil {
 		rk = event.OldObj().ResourceKind()
 	}
-	subs, exists := b.subscriberDir[rk]
+	states, exists := b.subscriberDir[rk]
 	if !exists {
 		logger.Infof("no subscriber for resource %s, skipped sending event%v", rk, event)
 		return
 	}
-	for _, sub := range subs {
-		// TODO Do we need to support reprocess
-		if err := sub.ProcessEvent(event); err != nil {
-			logger.Errorf("failed to process event in %s, cause: %s, event: %v", sub.Name(), err.Error(), event)
+	for _, st := range states {
+		if st.async && !st.closed.Load() {
+			select {
+			case st.ch <- event:
+			default:
+				logger.Warnf("async subscriber %s channel full (cap=%d), event dropped: %v",
+					st.subscriber.Name(), cap(st.ch), event)
+			}
+			continue
+		}
+		if !st.async {
+			// TODO Do we need to support reprocess
+			if err := st.subscriber.ProcessEvent(event); err != nil {
+				logger.Errorf("failed to process event in %s, cause: %s, event: %v",
+					st.subscriber.Name(), err.Error(), event)
+			}
 		}
 	}
+}
+
+func (b *eventBus) WaitForDone() {
+	b.stopped.Store(true)
+
+	b.rwMutex.Lock()
+	for _, states := range b.subscriberDir {
+		for _, st := range states {
+			if st.async && st.ch != nil && !st.closed.Load() {
+				st.closed.Store(true)
+				close(st.ch)
+			}
+		}
+	}
+	b.rwMutex.Unlock()
+
+	b.wg.Wait()
+}
+
+func (b *eventBus) launchDrainer(st *subscriberState) {
+	if b.stopped.Load() {
+		return
+	}
+	if !st.drainerStarted.CompareAndSwap(false, true) {
+		return
+	}
+
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		defer close(st.done)
+		for event := range st.ch {
+			if err := st.subscriber.ProcessEvent(event); err != nil {
+				logger.Errorf("async: failed to process event in %s, cause: %s, event: %v",
+					st.subscriber.Name(), err.Error(), event)
+			}
+		}
+	}()
 }

--- a/pkg/core/events/eventbus.go
+++ b/pkg/core/events/eventbus.go
@@ -45,6 +45,16 @@ type Subscriber interface {
 	Name() string
 
 	ProcessEvent(event Event) error
+
+	// AsyncEnabled controls whether this subscriber should be dispatched asynchronously.
+	//
+	// Return true when the subscriber may execute relatively slow logic and should not
+	// block EventBus.Send(). In async mode, EventBus enqueues events into a buffered
+	// channel and processes them in a dedicated drainer goroutine.
+	//
+	// Async dispatch is best-effort: when the subscriber queue is full, new events are
+	// dropped with a warning log.
+	AsyncEnabled() bool
 }
 
 type Subscribers []Subscriber

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -136,6 +136,11 @@ func (rt *runtime) Start(stop <-chan struct{}) error {
 	logger.Info("Admin started successfully")
 	select {
 	case <-stop:
+		for _, com := range components {
+			if gc, ok := com.(GracefulComponent); ok {
+				gc.WaitForDone()
+			}
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
## Background
EventBus previously dispatched events synchronously. Slow subscribers could block `Send()` and impact the whole event pipeline.

## What Changed
- Added optional async subscriber support via `AsyncSubscriber`.
- Refactored EventBus subscriber directory to maintain per-subscriber runtime state.
- Added per-subscriber async queue and drainer lifecycle control.
- Added lifecycle guard and graceful integration changes:
  - compile-time graceful component contract check
  - safer config validation path in `AdminConfig`
  - default eventbus buffer size aligned to `1024`

## Core Files
- `pkg/core/events/async.go`
- `pkg/core/events/component.go`
- `pkg/config/app/admin.go`
- `pkg/config/eventbus/config.go`

## Behavior Summary
- Async subscribers: non-blocking enqueue (`select` + `default`), drop with warn when channel is full.
- Sync subscribers: keep existing synchronous `ProcessEvent` behavior.
- Unsubscribe and shutdown paths keep graceful drain semantics.

## Notes
- This PR intentionally includes only core feature/code path updates.
- Test/documentation local changes are not included in this PR commit scope.
