### PR TITLE
fix: preserve large integers in service debug

### DIFF
--- a/ui-vue3/package.json
+++ b/ui-vue3/package.json
@@ -39,6 +39,7 @@
     "js-yaml": "^4.1.0",
     "less": "^4.2.0",
     "lodash": "^4.17.21",
+    "lossless-json": "^4.3.1",
     "monaco-editor": "^0.52.2",
     "nprogress": "^0.2.0",
     "pinia": "^2.1.7",

--- a/ui-vue3/src/utils/JsonUtil.spec.ts
+++ b/ui-vue3/src/utils/JsonUtil.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseJsonWithSafeNumbers } from './JsonUtil'
+
+describe('parseJsonWithSafeNumbers', () => {
+  it('preserves integers outside the JavaScript safe range', () => {
+    const args = parseJsonWithSafeNumbers<unknown[]>('[1694620889412087810]')
+
+    expect(args).toEqual(['1694620889412087810'])
+    expect(JSON.stringify({ args })).toBe('{"args":["1694620889412087810"]}')
+  })
+
+  it('keeps safe numbers as numbers and ignores numeric strings', () => {
+    const value = parseJsonWithSafeNumbers<{ text: string; value: number }>(
+      '{"text":"1694620889412087810","value":9007199254740991}'
+    )
+
+    expect(value).toEqual({ text: '1694620889412087810', value: 9007199254740991 })
+  })
+})

--- a/ui-vue3/src/utils/JsonUtil.ts
+++ b/ui-vue3/src/utils/JsonUtil.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isSafeNumber, parse } from 'lossless-json'
+
+export function parseJsonWithSafeNumbers<T>(text: string): T {
+  return parse(text, undefined, {
+    parseNumber: (value) => (isSafeNumber(value) ? parseFloat(value) : value)
+  }) as T
+}

--- a/ui-vue3/src/views/resources/services/tabs/debug.vue
+++ b/ui-vue3/src/views/resources/services/tabs/debug.vue
@@ -221,6 +221,7 @@ import {
   serviceGenericInvokeAPI
 } from '@/api/service/service'
 import { useMeshStore } from '@/stores/mesh'
+import { parseJsonWithSafeNumbers } from '@/utils/JsonUtil'
 
 defineOptions({
   name: 'ServiceDebugTab'
@@ -555,9 +556,11 @@ async function handleInvoke() {
   }
   let args: any[]
   try {
-    args = JSON.parse(requestValue.value)
-    if (!Array.isArray(args)) {
-      args = [args]
+    const parsedArgs = parseJsonWithSafeNumbers<unknown>(requestValue.value)
+    if (Array.isArray(parsedArgs)) {
+      args = parsedArgs
+    } else {
+      args = [parsedArgs]
     }
   } catch (error: any) {
     message.error('请求参数不是有效 JSON')

--- a/ui-vue3/yarn.lock
+++ b/ui-vue3/yarn.lock
@@ -4621,6 +4621,11 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lossless-json@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmmirror.com/lossless-json/-/lossless-json-4.3.1.tgz#ae1275f2f7e3aafdbf6985a42b6b604d848d716f"
+  integrity sha512-SqD/Bg3ZfltBJ2Z14hJ/BihnvtV553WO4g9/ePtlp4lrnl9jF3AdIJt53A/Wkg/0Li+LMfxaBqgx1MiFZdQlpQ==
+
 loupe@^2.3.6, loupe@^2.3.7:
   version "2.3.7"
   resolved "https://registry.npmmirror.com/loupe/-/loupe-2.3.7.tgz"


### PR DESCRIPTION
## Description

Preserve large integer values in the service debug request editor so snowflake IDs are not rounded by JavaScript's number handling.

## Changes

- Parse debug JSON with `lossless-json`.
- Keep unsafe numeric values as strings before sending the generic invoke request.
- Add regression tests for unsafe and safe numbers.

Closes #1245

## Verification

- `yarn test`
- Targeted ESLint passed.
- `yarn vite build`

Full repository lint and type-check remain blocked by existing baseline errors unrelated to this change.